### PR TITLE
Update eks module, fix cluster id output

### DIFF
--- a/tf-modules/aws/eks/main.tf
+++ b/tf-modules/aws/eks/main.tf
@@ -1,9 +1,9 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 18"
+  version = "~> 19"
 
   cluster_name    = var.name
-  cluster_version = "1.22"
+  cluster_version = "1.23"
 
   # Maybe don't need any of these?
   cluster_endpoint_private_access = true

--- a/tf-modules/aws/eks/outputs.tf
+++ b/tf-modules/aws/eks/outputs.tf
@@ -1,6 +1,6 @@
 output "cluster_id" {
   description = "ID of the created EKS cluster"
-  value       = module.eks.cluster_id
+  value       = module.eks.cluster_name
 }
 
 output "cluster_ca_data" {


### PR DESCRIPTION
- Update terraform EKS module to use v19 and above.
- EKS module v19 introduced [breaking change](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v19.0.0) for `cluster_id` output. Replace `cluster_id` with `cluster_name` in the test EKS module to handle this fix transparently for the consumers of the module.
- Update cluster version to 1.23, current EKS default.