### PR TITLE
Add client_id to aks module output

### DIFF
--- a/tf-modules/azure/aks/outputs.tf
+++ b/tf-modules/azure/aks/outputs.tf
@@ -9,6 +9,11 @@ output "principal_id" {
   value       = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
 }
 
+output "kubelet_client_id" {
+  description = "Azure Client ID of the AKS cluster"
+  value       = azurerm_kubernetes_cluster.this.kubelet_identity[0].client_id
+}
+
 output "resource_group" {
   description = "Azure Resource Group in which the AKS cluster is created"
   value       = azurerm_resource_group.this.name


### PR DESCRIPTION
This pull requests outputs the kubelet client_id in the aks module.
The client_id is used for the sops secret when configuring managed identity on Azure.

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>