### PR TITLE
reaper: provide response content when unmarshal fails

### DIFF
--- a/tools/reaper/main.go
+++ b/tools/reaper/main.go
@@ -249,7 +249,9 @@ func parseJSONResources(r []byte) ([]resource, error) {
 	}
 	var resources []resource
 	if err := json.Unmarshal(r, &resources); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+		// When unmarshal fails, provide the full output response to make it
+		// easier to see the content of response that it failed to unmarshal.
+		return nil, fmt.Errorf("failed to unmarshal: %w, content: %q", err, string(r))
 	}
 	return resources, nil
 }


### PR DESCRIPTION
When unmarshalling of query response fails, provide the content of the response to make it easier to understand the issue.

reaper failed in pkg repo with error:

```
2023/05/15 11:55:09 Query error: failed to unmarshal: invalid character 'A' looking for beginning of value
```
Refer https://github.com/fluxcd/pkg/actions/runs/4979912440/jobs/8912331038#step:11:84

The actual content was:
```
API [cloudasset.googleapis.com] not enabled on project [xxxxxxx]. Would you like to enable and retry (this will take a few minutes)? (y/N)?
```

