### PR TITLE
tf-modules/aws: Pin AWS provider

### DIFF
--- a/tf-modules/aws/ecr/versions.tf
+++ b/tf-modules/aws/ecr/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = "~> 4.22"
     }
   }
 }

--- a/tf-modules/aws/eks/versions.tf
+++ b/tf-modules/aws/eks/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22"
+      version = "~> 4.22"
     }
   }
 }


### PR DESCRIPTION
aws provider v5 introduces a lot of [breaking changes](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#500-may-25-2023) which isn't supported in the eks module we use yet. Pin to the v4 version range of aws-provider for now.