### PR TITLE
tf-modules/aws: remove provider configuration

### DIFF
--- a/tf-modules/aws/ecr/README.md
+++ b/tf-modules/aws/ecr/README.md
@@ -10,7 +10,7 @@ provider "aws" {}
 
 resource "random_pet" "suffix" {}
 
-module "eks" {
+module "ecr" {
     source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/aws/ecr"
 
     name = "flux-test-${random_pet.suffix.id}"

--- a/tf-modules/aws/ecr/main.tf
+++ b/tf-modules/aws/ecr/main.tf
@@ -4,14 +4,9 @@ module "tags" {
   tags = var.tags
 }
 
-provider "aws" {
-  default_tags {
-    tags = module.tags.tags
-  }
-}
-
 resource "aws_ecr_repository" "this" {
   name                 = var.name
   image_tag_mutability = "MUTABLE"
   force_delete         = true
+  tags                 = module.tags.tags
 }

--- a/tf-modules/aws/eks/main.tf
+++ b/tf-modules/aws/eks/main.tf
@@ -4,12 +4,6 @@ module "tags" {
   tags = var.tags
 }
 
-provider "aws" {
-  default_tags {
-    tags = module.tags.tags
-  }
-}
-
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 19"
@@ -51,6 +45,8 @@ module "eks" {
       capacity_type  = "SPOT"
     }
   }
+
+  tags = module.tags.tags
 }
 
 data "aws_caller_identity" "current" {}
@@ -83,4 +79,6 @@ module "vpc" {
     "kubernetes.io/cluster/${var.name}" = "shared"
     "kubernetes.io/role/internal-elb"   = 1
   }
+
+  tags = module.tags.tags
 }


### PR DESCRIPTION
Initially, the provider configuration was added in the aws modules in https://github.com/fluxcd/test-infra/pull/7 to configure the tags on all the aws resources. Other cloud providers require the tags to be configured per resource. AWS allows configuring the default tags at the provider level. It's a better practice for terraform modules to not have provider configuration in them, they should be configured in the root module.

Remove provider configuration from the aws modules to allow configuring the provider configuration by the module user. This allows a root configuration to have different provider configurations that can be used to configure multiple instances of a module differently.

A user of these aws module should be able to use the same module to create EKS clusters and ECR repositories in different regions.