### PR TITLE
Add gcp github actions tf module

### DIFF
--- a/tf-modules/gcp/github-actions/README.md
+++ b/tf-modules/gcp/github-actions/README.md
@@ -1,0 +1,92 @@
+# Google Cloud Platform GitHub Actions Secrets and Variables
+
+This terraform module registers a GCP service account to be used in CI, grants
+the provided IAM permissions to the service account and generates a JSON key for
+the service account. The JSON key along with the provider details are then
+written to GitHub actions secrets and variables of the given repository.
+
+By default, the following GitHub actions variables are created:
+- `TF_VAR_gcp_project_id`
+- `TF_VAR_gcp_region`
+- `TF_VAR_gcp_zone`
+
+and `GOOGLE_APPLICATION_CREDENTIALS` actions secret is created. All of these
+names are overridable, see `variables.tf`.
+
+It also supports adding custom secrets and variables in addition to the above.
+
+**NOTE:** Overwriting existing GitHub secrets and variables are not supported.
+
+## Usage
+
+```hcl
+provider "google" {}
+
+module "gcp_gh_actions" {
+    source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/gcp/github-actions"
+
+    gcp_service_account_id = "test-sa-1"
+    gcp_service_account_name = "test-sa-1"
+    gcp_roles = [
+        "roles/compute.instanceAdmin.v1",
+        "roles/container.admin"
+    ]
+
+    github_project = "repo-name"
+
+    github_variable_custom = {
+        "SOME_VAR1" = "some-val1",
+        "SOME_var2" = "some-val2"
+    }
+
+    github_secret_custom = {
+        "SECRET1" = "some-secret1",
+        "SECRET2" = "some-secret2"
+    }
+}
+```
+
+**NOTE:** The JSON key is generated and downloaded locally and is compressed
+using jq before writing to GitHub repository. This leaves behind a local copy of
+the JSON key. Ensure that they are deleted after the usage. See variable
+`gcp_encoded_key_path` and `gcp_compressed_key_path` variables for the file
+paths. Since the service account key is only generated the first time, deleting
+these files leave no reference of the key and subsequent terraform apply or
+destroy would fail without their existence.
+
+## Requirements
+
+This module depends on `base64` and `jq` for decoding and compressing the JSON
+key before writing them to GitHub repository. These are required to be
+preinstalled on the host machine.
+
+### GCP Requirements
+
+Grant the following IAM permissions:
+- Project IAM Admin - `roles/resourcemanager.projectIamAdmin`
+- Service Account Admin - `roles/iam.serviceAccountAdmin`
+- Service Account Key Admin - `roles/iam.serviceAccountKeyAdmin`
+
+### GitHub Requirements
+
+Create a GitHub fine-grained token for the target repository with the following
+repository permissions:
+- `Read access to metadata`
+- `Read and Write access to actions variables and secrets`
+
+## Provider Configuration
+
+Configure the Google and GitHub provider with the following environment
+variables:
+```sh
+export GOOGLE_PROJECT=""
+export GOOGLE_REGION=""
+export GOOGLE_ZONE=""
+
+export GITHUB_TOKEN=""
+```
+
+Also use `GOOGLE_APPLICATION_CREDENTIALS` when authenticating with a service
+account.
+
+Check the respective provider docs for more details.

--- a/tf-modules/gcp/github-actions/main.tf
+++ b/tf-modules/gcp/github-actions/main.tf
@@ -1,0 +1,85 @@
+data "google_client_config" "this" {}
+
+locals {
+  # Set the provider values from input variables and provider configuration.
+  project_id = var.gcp_project_id == "" ? data.google_client_config.this.project : var.gcp_project_id
+  region     = var.gcp_region == "" ? data.google_client_config.this.region : var.gcp_region
+  zone       = var.gcp_zone == "" ? data.google_client_config.this.zone : var.gcp_zone
+}
+
+# Create service account, grant permissions and generate the JSON key.
+resource "google_service_account" "service_account" {
+  account_id   = var.gcp_service_account_id
+  display_name = var.gcp_service_account_name
+}
+
+resource "google_project_iam_member" "role_binding" {
+  for_each = toset(var.gcp_roles)
+
+  project = local.project_id
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_service_account_key" "key" {
+  service_account_id = google_service_account.service_account.name
+
+  # The JSON key is base64 encoded and prettified. Before using the key in
+  # GitHub action, it has to be decoded and compressed. Write the key in a local
+  # file and operate on it.
+  provisioner "local-exec" {
+    command = "echo ${self.private_key} > ${var.gcp_encoded_key_path}"
+  }
+  provisioner "local-exec" {
+    command = "cat encoded.txt | base64 -d | jq -r tostring > ${var.gcp_compressed_key_path}"
+  }
+}
+
+# Load the compressed JSON key.
+data "local_sensitive_file" "compressed" {
+  filename = var.gcp_compressed_key_path
+
+  depends_on = [google_service_account_key.key]
+}
+
+# Add variables and secrets in github repo.
+resource "github_actions_variable" "project_id" {
+  repository    = var.github_project
+  variable_name = var.github_variable_project_id_name
+  value         = local.project_id
+}
+
+resource "github_actions_variable" "region" {
+  repository    = var.github_project
+  variable_name = var.github_variable_region_name
+  value         = local.region
+}
+
+resource "github_actions_variable" "zone" {
+  repository    = var.github_project
+  variable_name = var.github_variable_zone_name
+  value         = local.zone
+}
+
+resource "github_actions_secret" "credentials" {
+  repository      = var.github_project
+  secret_name     = var.github_secret_credentials_name
+  plaintext_value = data.local_sensitive_file.compressed.content
+}
+
+resource "github_actions_variable" "custom" {
+  for_each = var.github_variable_custom
+
+  repository    = var.github_project
+  variable_name = each.key
+  value         = each.value
+}
+
+resource "github_actions_secret" "custom" {
+  # Mark only the key as nonsensitive.
+  for_each = nonsensitive(toset(keys(var.github_secret_custom)))
+
+  repository      = var.github_project
+  secret_name     = each.key
+  plaintext_value = var.github_secret_custom[each.key]
+}

--- a/tf-modules/gcp/github-actions/variables.tf
+++ b/tf-modules/gcp/github-actions/variables.tf
@@ -1,0 +1,87 @@
+variable "github_project" {
+  description = "Name of the GitHub project to add secrets and variables to"
+  type        = string
+}
+
+variable "gcp_project_id" {
+  description = "GCP project to create the resources in"
+  type        = string
+  default     = ""
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+  default     = ""
+}
+
+variable "gcp_zone" {
+  description = "GCP zone"
+  type        = string
+  default     = ""
+}
+
+variable "gcp_service_account_id" {
+  description = "GCP Service Account ID"
+  type        = string
+}
+
+variable "gcp_service_account_name" {
+  description = "GCP Service Account display name"
+  type        = string
+}
+
+variable "gcp_roles" {
+  description = "List of permissions to grant to the service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "gcp_encoded_key_path" {
+  description = "File path of the encoded GCP json key"
+  type        = string
+  default     = "encoded.txt"
+}
+
+variable "gcp_compressed_key_path" {
+  description = "File path of the compressed GCP json key"
+  type        = string
+  default     = "compressed.txt"
+}
+
+variable "github_variable_project_id_name" {
+  description = "GitHub variable name for GCP project ID"
+  type        = string
+  default     = "TF_VAR_gcp_project_id"
+}
+
+variable "github_variable_region_name" {
+  description = "GitHub variable name for GCP region"
+  type        = string
+  default     = "TF_VAR_gcp_region"
+}
+
+variable "github_variable_zone_name" {
+  description = "GitHub variable name for GCP zone"
+  type        = string
+  default     = "TF_VAR_gcp_zone"
+}
+
+variable "github_secret_credentials_name" {
+  description = "GitHub secret name for Google application credentials"
+  type        = string
+  default     = "GOOGLE_APPLICATION_CREDENTIALS"
+}
+
+variable "github_variable_custom" {
+  description = "A map of custom GitHub variables to be created"
+  type        = map(string)
+  default     = {}
+}
+
+variable "github_secret_custom" {
+  description = "A map of custom GitHub secrets to be created"
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}

--- a/tf-modules/gcp/github-actions/versions.tf
+++ b/tf-modules/gcp/github-actions/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.73.1"
+    }
+
+    github = {
+      source  = "integrations/github"
+      version = ">= 5.28.1"
+    }
+  }
+}


### PR DESCRIPTION
This tf-module automates the creation of GCP service account and the required permissions to run the tests on GitHub by automatically writing the generated secrets in GitHub actions secrets and variables.