### PR TITLE
GCP: Add description for the service account

### DIFF
--- a/tf-modules/gcp/github-actions/README.md
+++ b/tf-modules/gcp/github-actions/README.md
@@ -25,8 +25,9 @@ provider "google" {}
 module "gcp_gh_actions" {
     source = "git::https://github.com/fluxcd/test-infra.git//tf-modules/gcp/github-actions"
 
-    gcp_service_account_id = "test-sa-1"
-    gcp_service_account_name = "test-sa-1"
+    gcp_service_account_id          = "test-sa-1"
+    gcp_service_account_name        = "test-sa-1"
+    gcp_service_account_description = "For running e2e tests"
     gcp_roles = [
         "roles/compute.instanceAdmin.v1",
         "roles/container.admin"

--- a/tf-modules/gcp/github-actions/main.tf
+++ b/tf-modules/gcp/github-actions/main.tf
@@ -11,6 +11,7 @@ locals {
 resource "google_service_account" "service_account" {
   account_id   = var.gcp_service_account_id
   display_name = var.gcp_service_account_name
+  description  = var.gcp_service_account_description
 }
 
 resource "google_project_iam_member" "role_binding" {

--- a/tf-modules/gcp/github-actions/variables.tf
+++ b/tf-modules/gcp/github-actions/variables.tf
@@ -31,6 +31,11 @@ variable "gcp_service_account_name" {
   type        = string
 }
 
+variable "gcp_service_account_description" {
+  description = "GCP Service Account description"
+  type        = string
+}
+
 variable "gcp_roles" {
   description = "List of permissions to grant to the service account"
   type        = list(string)


### PR DESCRIPTION
This allows setting description for the service account created using the gcp/github-actions/ module.

I've tested this manually for flux2 e2e test setup.