### PR TITLE
Enable Workload Identity on GCP / AWS

### DIFF
--- a/tf-modules/aws/eks/outputs.tf
+++ b/tf-modules/aws/eks/outputs.tf
@@ -23,3 +23,13 @@ output "region" {
   description = "Region in which the EKS cluster is created"
   value       = data.aws_region.current.name
 }
+
+output "cluster_oidc_url" {
+  value       = module.eks.cluster_oidc_issuer_url
+  description = "The OIDC Issuer URL of the EKS cluster"
+}
+
+output "cluster_oidc_arn" {
+  value       = module.eks.oidc_provider_arn
+  description = "The ARN of the OIDC Provider"
+}

--- a/tf-modules/gcp/gke/main.tf
+++ b/tf-modules/gcp/gke/main.tf
@@ -6,6 +6,8 @@ module "tags" {
 
 data "google_client_config" "this" {}
 
+data "google_project" "this" {}
+
 resource "google_container_cluster" "primary" {
   name               = var.name
   location           = data.google_client_config.this.region
@@ -15,10 +17,14 @@ resource "google_container_cluster" "primary" {
     disk_size_gb = 10
 
     # Set the scope to grant the nodes all the API access.
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform"
-    ]
+    oauth_scopes = var.oauth_scopes
+
   }
+
+  workload_identity_config {
+    workload_pool = var.enable_wi == false ? null : "${data.google_project.this.project_id}.svc.id.goog"
+  }
+
   resource_labels = module.tags.tags
 }
 

--- a/tf-modules/gcp/gke/variables.tf
+++ b/tf-modules/gcp/gke/variables.tf
@@ -8,3 +8,16 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "enable_wi" {
+  default     = false
+  type        = bool
+  description = "enable workload identity for the cluster"
+}
+
+variable "oauth_scopes" {
+  type = list(string)
+  default = [
+    "https://www.googleapis.com/auth/cloud-platform"
+  ]
+}


### PR DESCRIPTION
For AWS, IRSA is enabled by default. Some output from the `eks` module is exported that will be used for creating the `AssumeRoleWithWebIdentity` role.