### PR TITLE
tf-modules/gcp/gke: ignore node_config changes

### DIFF
--- a/tf-modules/gcp/gke/README.md
+++ b/tf-modules/gcp/gke/README.md
@@ -22,3 +22,9 @@ module "gke" {
     name = "flux-test-${random_pet.suffix.id}"
 }
 ```
+
+**:warning: WARNING:** This module ignores changes to the
+`google_container_cluster.node_config` using [lifecycle
+meta-argument](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes).
+Please consider updating the lifecycle arguments when there's a need to update
+the `node_config` post provision.

--- a/tf-modules/gcp/gke/main.tf
+++ b/tf-modules/gcp/gke/main.tf
@@ -26,6 +26,20 @@ resource "google_container_cluster" "primary" {
   }
 
   resource_labels = module.tags.tags
+
+  lifecycle {
+    ignore_changes = [
+      # When enabling workload identity, the oauth_scopes in node_config is set
+      # to be empty at provision time. But after provision, some default scopes
+      # get attached. Reapplying the same config tries to remove the existing
+      # oauth scopes for empty scopes. Oauth scopes replacement requires
+      # destroying and creating a new cluster. To prevent such cluster
+      # recreation, ignore any change in node_config.
+      # node_config[0].oauth_scopes can ignore just oauth_scopes of the first
+      # node_config, but for simplicity, ignore the whole node_config change.
+      node_config
+    ]
+  }
 }
 
 # auth module to retrieve kubeconfig of the created cluster.


### PR DESCRIPTION
When using workload identity in GKE, an empty `node_config.oauth_scopes` is set at provision time. But after the provision, some default scopes are added to the cluster. Reapplying the same config tries to replace the existing scopes with empty scopes. This replacement requires the existing cluster to be deleted and recreated. To avoid cluster recreation between test runs, set a lifecycle rule to ignore any changes in node_config.

Encountered this while testing https://github.com/fluxcd/pkg/pull/665 . Was observing the following when rerunning the tests:

```console
  # module.gke.google_container_cluster.primary must be replaced
-/+ resource "google_container_cluster" "primary" {
      ...

          ~ oauth_scopes      = [ # forces replacement
              - "https://www.googleapis.com/auth/devstorage.read_only",
              - "https://www.googleapis.com/auth/logging.write",
              - "https://www.googleapis.com/auth/monitoring",
              - "https://www.googleapis.com/auth/service.management.readonly",
              - "https://www.googleapis.com/auth/servicecontrol",
              - "https://www.googleapis.com/auth/trace.append",
              + "https://www.googleapis.com/auth/cloud-platform",
            ]
      ...
```