### PR TITLE
GKE: set delete_protection to false

### DIFF
--- a/tf-modules/gcp/gke/main.tf
+++ b/tf-modules/gcp/gke/main.tf
@@ -25,6 +25,8 @@ resource "google_container_cluster" "primary" {
     workload_pool = var.enable_wi == false ? null : "${data.google_project.this.project_id}.svc.id.goog"
   }
 
+  deletion_protection = false
+
   resource_labels = module.tags.tags
 }
 


### PR DESCRIPTION
terraform-provider-google enables delete_protection by default for all the GKE clusters. This prevents the clusters from getting deleted at the end of test runs. Set it to false to remove the protection by default. Test infrastructure are short lived and don't need delete protection.

Refer https://github.com/hashicorp/terraform-provider-google/releases/tag/v5.0.0 
