### PR TITLE
tools/reaper: fatal when resources are not deleted

### DIFF
--- a/tools/reaper/README.md
+++ b/tools/reaper/README.md
@@ -37,6 +37,8 @@ compute.googleapis.com/InstanceTemplate: gke-flux-test-full-dove-default-pool-42
 compute.googleapis.com/InstanceTemplate: gke-flux-test-full-dove-default-pool-dcded0bb
 container.googleapis.com/Cluster: flux-test-full-dove
 artifactregistry.googleapis.com/Repository: projects/darkowlzz-gcp/locations/us-central1/repositories/flux-test-full-dove
+2023/11/04 00:49:45 resources found but not deleted
+exit status 1
 ```
 
 JSON output is also supported:

--- a/tools/reaper/main.go
+++ b/tools/reaper/main.go
@@ -205,6 +205,11 @@ func main() {
 				}
 			}
 		}
+	} else if !*delete && len(resources) > 0 {
+		// Exit with non-zero exit code when resources are found but not
+		// deleted. This is to help detect stale resources when run in CI by
+		// failing the job.
+		log.Fatal("resources found but not deleted")
 	}
 }
 


### PR DESCRIPTION
When resources are found but not deleted, fail to help detect that stale resources were found but not deleted.

```console
$ go run ./ -provider gcp -tags 'environment=dev' -gcpproject test-project
Total resources found: 11
artifactregistry.googleapis.com/Repository: projects/test-project/locations/us-central1/repositories/flux-test-sharing-sawfly
compute.googleapis.com/Instance: gke-flux-test-sharing-sa-default-pool-9ff69617-gk5w
compute.googleapis.com/Disk: gke-flux-test-sharing-sa-default-pool-9ff69617-gk5w
compute.googleapis.com/Instance: gke-flux-test-sharing-sa-default-pool-314d00bb-l1k6
compute.googleapis.com/Disk: gke-flux-test-sharing-sa-default-pool-314d00bb-l1k6
compute.googleapis.com/Disk: gke-flux-test-sharing-sa-default-pool-310d55fd-xjd5
compute.googleapis.com/Instance: gke-flux-test-sharing-sa-default-pool-310d55fd-xjd5
compute.googleapis.com/InstanceTemplate: gke-flux-test-sharing-sa-default-pool-310d55fd
compute.googleapis.com/InstanceTemplate: gke-flux-test-sharing-sa-default-pool-314d00bb
compute.googleapis.com/InstanceTemplate: gke-flux-test-sharing-sa-default-pool-9ff69617
container.googleapis.com/Cluster: flux-test-sharing-sawfly
2023/11/04 00:49:45 resources found but not deleted
exit status 1
```

Related to the incident described in https://github.com/fluxcd/pkg/pull/682, to be able to detect such situations easily in the future.