### PR TITLE
GKE: Add release channel option

### DIFF
--- a/tf-modules/gcp/gke/main.tf
+++ b/tf-modules/gcp/gke/main.tf
@@ -21,6 +21,10 @@ resource "google_container_cluster" "primary" {
 
   }
 
+  release_channel {
+    channel = var.release_channel
+  }
+
   workload_identity_config {
     workload_pool = var.enable_wi == false ? null : "${data.google_project.this.project_id}.svc.id.goog"
   }

--- a/tf-modules/gcp/gke/variables.tf
+++ b/tf-modules/gcp/gke/variables.tf
@@ -21,3 +21,9 @@ variable "oauth_scopes" {
     "https://www.googleapis.com/auth/cloud-platform"
   ]
 }
+
+variable "release_channel" {
+  description = "GKE release channel to use for the cluster"
+  type        = string
+  default     = "REGULAR"
+}


### PR DESCRIPTION
Release channel allows using different versions of the cluster easily without entering the exact version. This can be used by the individual tests to select the GKE release channel to test against.