### PR TITLE
Fix AWS terraform module and update dependencies

### DIFF
--- a/tf-modules/aws/ecr/versions.tf
+++ b/tf-modules/aws/ecr/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.22"
+      version = ">= 5.40"
     }
   }
 }

--- a/tf-modules/aws/eks/main.tf
+++ b/tf-modules/aws/eks/main.tf
@@ -6,10 +6,10 @@ module "tags" {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19"
+  version = "~> 20.0"
 
   cluster_name    = var.name
-  cluster_version = "1.25"
+  cluster_version = "1.29"
 
   # Maybe don't need any of these?
   cluster_endpoint_private_access = true
@@ -46,6 +46,8 @@ module "eks" {
     }
   }
 
+  enable_cluster_creator_admin_permissions = true
+
   tags = module.tags.tags
 }
 
@@ -57,7 +59,7 @@ data "aws_availability_zones" "available" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = var.name
   cidr = "10.0.0.0/16"

--- a/tf-modules/aws/eks/versions.tf
+++ b/tf-modules/aws/eks/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.22"
+      version = ">= 5.40"
     }
   }
 }


### PR DESCRIPTION
- Unpin aws terraform provider from v4 and use the latest v5 provider. This was pinned before due to breaking changes that were not adopted by terraform-aws-modules, refer https://github.com/fluxcd/test-infra/pull/11 for more details.
- Update terraform-aws-modules/{eks,vpc} to their latest version.
- Set `enable_cluster_creator_admin_permissions` to true in the EKS module resource to add an IAM access entry for the cluster creator IAM user. Without this, the generated kubeconfig has no access to the cluster API server.
- Update EKS cluster to 1.29. (Option to change this using a variable will be added separately.)

Tested these changes with the [fluxcd/pkg/oci/tests/integration](https://github.com/fluxcd/pkg/tree/main/oci/tests/integration) tests, which didn't work before due to the new IAM access entry requirement.

Part of: https://github.com/fluxcd/flux2/issues/4619