### PR TITLE
EKS: Disable cloudwatch logs & cluster encryption

### DIFF
--- a/tf-modules/aws/eks/main.tf
+++ b/tf-modules/aws/eks/main.tf
@@ -28,6 +28,7 @@ module "eks" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
+  # Define the default node group configuration.
   eks_managed_node_group_defaults = {
     disk_size            = 50
     instance_types       = ["t2.medium"]
@@ -35,6 +36,7 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
+    # Create node groups using on-demand nodes and spot nodes.
     blue = {}
     green = {
       min_size     = 1
@@ -47,6 +49,14 @@ module "eks" {
   }
 
   enable_cluster_creator_admin_permissions = true
+
+  # Disable log aggregation for such ephemeral clusters.
+  cluster_enabled_log_types   = []
+  create_cloudwatch_log_group = false
+
+  # Disable encryption unless it's needed for some test.
+  cluster_encryption_config = {}
+  create_kms_key            = false
 
   tags = module.tags.tags
 }


### PR DESCRIPTION
Cloudwatch logs and cluster encryption are not needed for the current test infrastructure needs.
It is also a workaround for a [bug](https://github.com/rebuy-de/aws-nuke/issues/500) in aws-nuke which gets stuck because the log group gets recreated by the EKS cluster. Consecutive nuke run clears the resources. 
Disabling cluster encryption helps reduce KMS usage and reduce cost. It can be enabled if needed in the future.

Related to https://github.com/fluxcd/test-infra/pull/39